### PR TITLE
Pattern mismatch error resolved by adding 'enterprises/' before enterprise_name 

### DIFF
--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -276,7 +276,7 @@
       "source": [
         "import json\n",
         "\n",
-        "policy_name = enterprise_name + '/policies/policy1'\n",
+        "policy_name = 'enterprises/' + enterprise_name + '/policies/policy1'\n",
         "\n",
         "policy_json = '''\n",
         "{\n",
@@ -326,7 +326,7 @@
       "outputs": [],
       "source": [
         "enrollment_token = androidmanagement.enterprises().enrollmentTokens().create(\n",
-        "    parent=enterprise_name,\n",
+        "    parent='enterprises/' + enterprise_name,\n",
         "    body={\"policyName\": policy_name}\n",
         ").execute()"
       ]


### PR DESCRIPTION
added 'enterprises/' before enterprise_name in Create a policy and Provision a device using a QR code to overcome this error: TypeError: Parameter "name" value "LC01gzjgxa/policies/policy1" does not match the pattern "^enterprises/[^/]+/policies/[^/]+$"

for more details please check: [https://stackoverflow.com/q/53954963/9752602](url)